### PR TITLE
fix(trf): count points only until player advances or eliminated

### DIFF
--- a/fileformats/trf.cpp
+++ b/fileformats/trf.cpp
@@ -682,9 +682,22 @@ namespace fileformats
             }
             tournament::points points{ };
             tournament::round_index matchIndex{ };
+            // Only count points up until player becomes advanced/eliminated
+            tournament::round_index lastRoundToCount = tournament.playedRounds;
+            if (player.status != 0) {
+              // Look for first match after becoming advanced/eliminated
+              for (tournament::round_index i = 0; i < player.matches.size(); i++) {
+                const tournament::Match &match = player.matches[i];
+                if (match.matchScore == tournament::MATCH_SCORE_LOSS && !match.gameWasPlayed && !match.participatedInPairing) {
+                  lastRoundToCount = i;
+                  break;
+                }
+              }
+            }
+            
             for (const tournament::Match &match : player.matches)
             {
-              if (matchIndex >= tournament.playedRounds)
+              if (matchIndex >= lastRoundToCount)
               {
                 break;
               }


### PR DESCRIPTION
Adjust point calculation to stop counting matches after a player becomes advanced or eliminated. This prevents including matches that were not played or participated in after status change, ensuring accurate tournament scoring and standings.